### PR TITLE
Pass missing method calls onto the containing model object

### DIFF
--- a/behaviors/Notifiable.php
+++ b/behaviors/Notifiable.php
@@ -9,7 +9,7 @@ class Notifiable extends \October\Rain\Database\ModelBehavior
     public function __call($name, $params = null)
     {
         if (!method_exists($this, $name) || !is_callable($this, $name) {
-            call_user_func_array([$this->model, $name], $params);
+            return call_user_func_array([$this->model, $name], $params);
         }
     }
 }

--- a/behaviors/Notifiable.php
+++ b/behaviors/Notifiable.php
@@ -2,14 +2,14 @@
 
 use Illuminate\Notifications\Notifiable as NotifiableTrait;
 
-class Notifiable extends \October\Rain\Extension\ExtensionBase
+class Notifiable extends \October\Rain\Database\ModelBehavior
 {
     use NotifiableTrait;
 
-    protected $parent;
-
-    public function __construct($parent)
+    public function __call($name, $params = null)
     {
-        $this->parent = $parent;
+        if (!method_exists($this, $name) || !is_callable($this, $name) {
+            call_user_func_array([$this->model, $name], $params);
+        }
     }
 }


### PR DESCRIPTION
Attempt to properly encapsulate method calls from a model trait that expects to be attached to a model when it is attached to a behaviour that is attached to a model instead.